### PR TITLE
Soft-Delete

### DIFF
--- a/dataservice/Application/Repositories/ColorRepo.cs
+++ b/dataservice/Application/Repositories/ColorRepo.cs
@@ -39,7 +39,7 @@ namespace Application.Repositories
 
         public IEnumerable<MedicineColor> GetColors()
         {
-            return _context.Medicine_Colors;
+            return _context.Medicine_Colors.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower().ToString().ToLower());
         }
 
         public Result RemoveColor(string color)
@@ -50,7 +50,8 @@ namespace Application.Repositories
                 return new Result(false, "No color by the given name has been found");
             }
 
-            _context.Medicine_Colors.Remove(medicineColor);
+            medicineColor.Status = Domain.EntityStatus.Archived.ToString().ToLower().ToString().ToLower(); //Soft-Delete
+            _context.Medicine_Colors.Update(medicineColor);
             _context.SaveChanges();
             return new Result(true);
         }

--- a/dataservice/Application/Repositories/ColorRepo.cs
+++ b/dataservice/Application/Repositories/ColorRepo.cs
@@ -39,7 +39,7 @@ namespace Application.Repositories
 
         public IEnumerable<MedicineColor> GetColors()
         {
-            return _context.Medicine_Colors.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower().ToString().ToLower());
+            return _context.Medicine_Colors.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower());
         }
 
         public Result RemoveColor(string color)
@@ -50,7 +50,7 @@ namespace Application.Repositories
                 return new Result(false, "No color by the given name has been found");
             }
 
-            medicineColor.Status = Domain.EntityStatus.Archived.ToString().ToLower().ToString().ToLower(); //Soft-Delete
+            medicineColor.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
             _context.Medicine_Colors.Update(medicineColor);
             _context.SaveChanges();
             return new Result(true);

--- a/dataservice/Application/Repositories/DoseUnitRepo.cs
+++ b/dataservice/Application/Repositories/DoseUnitRepo.cs
@@ -39,7 +39,7 @@ namespace Application.Repositories
 
         public IEnumerable<DoseUnit> GetDoseUnits()
         {
-            return _context.DoseUnits;
+            return _context.DoseUnits.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower()); ;
         }
 
         public Result RemoveDoseUnit(string unit)
@@ -50,7 +50,8 @@ namespace Application.Repositories
                 return new Result(false, "No dose unit by the given name has been found");
             }
 
-            _context.DoseUnits.Remove(doseUnit);
+            doseUnit.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
+            _context.DoseUnits.Update(doseUnit);
             _context.SaveChanges();
             return new Result(true);
         }

--- a/dataservice/Application/Repositories/MedicineRepo.cs
+++ b/dataservice/Application/Repositories/MedicineRepo.cs
@@ -56,14 +56,15 @@ namespace Application.Repositories
                 return new Result(false, "No medicine with given Id exists.");
             }
 
-            _context.Medicine.Remove(medicine);
+            medicine.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
+            _context.Medicine.Update(medicine);
             _context.SaveChanges();
             return new Result(true);
         }
 
         public IEnumerable<Medicine> GetAllMedicine()
         {
-            return _context.Medicine;
+            return _context.Medicine.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower()); ;
         }
 
         public Medicine? GetMedicine(int id)

--- a/dataservice/Application/Repositories/PatientIntakeRepo.cs
+++ b/dataservice/Application/Repositories/PatientIntakeRepo.cs
@@ -50,7 +50,7 @@ namespace Application.Repositories
 
         public IEnumerable<PatientIntake> GetIntakesByPatientId(int patientId)
         {
-            return _medicineDbContext.PatientIntakes.Include(x => x.Medicine).Where(x => x.PatientId == patientId);
+            return _medicineDbContext.PatientIntakes.Include(x => x.Medicine).Where(x => x.PatientId == patientId).Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower()); ;
         }
 
         public Result RemoveIntake(int id)
@@ -61,7 +61,8 @@ namespace Application.Repositories
                 return new Result(false, "No intake with given id exists");
             }
 
-            _medicineDbContext.Remove(foundIntake);
+            foundIntake.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
+            _medicineDbContext.PatientIntakes.Update(foundIntake);
             _medicineDbContext.SaveChanges();
             return new Result(true);
         }

--- a/dataservice/Application/Repositories/PatientRepo.cs
+++ b/dataservice/Application/Repositories/PatientRepo.cs
@@ -52,7 +52,7 @@ namespace Application.Repositories
 
         public IEnumerable<Patient> GetAllPatients()
         {
-            return _context.Patients;
+            return _context.Patients.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower()); ;
         }
 
         public Result RemovePatient(int id)
@@ -63,7 +63,8 @@ namespace Application.Repositories
                 return new Result(false, "No patient with given id has been found");
             }
 
-            _context.Remove(patient);
+            patient.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
+            _context.Patients.Update(patient);
             _context.SaveChanges();
             return new Result(true);
         }

--- a/dataservice/Application/Repositories/ShapeRepo.cs
+++ b/dataservice/Application/Repositories/ShapeRepo.cs
@@ -39,7 +39,7 @@ namespace Application.Repositories
 
         public IEnumerable<MedicineShape> GetShapes()
         {
-            return _context.Medicine_Shapes;
+            return _context.Medicine_Shapes.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower()); ;
         }
 
         public Result RemoveShape(string shape)
@@ -50,7 +50,8 @@ namespace Application.Repositories
                 return new Result(false, "No shape by the given name has been found");
             }
 
-            _context.Medicine_Shapes.Remove(medicineShape);
+            medicineShape.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
+            _context.Medicine_Shapes.Update(medicineShape);
             _context.SaveChanges();
             return new Result(true);
         }

--- a/dataservice/Application/Repositories/TypeRepo.cs
+++ b/dataservice/Application/Repositories/TypeRepo.cs
@@ -39,7 +39,7 @@ namespace Application.Repositories
 
         public IEnumerable<MedicineType> GetTypes()
         {
-            return _context.Medicine_Types;
+            return _context.Medicine_Types.Where(x => x.Status == Domain.EntityStatus.Active.ToString().ToLower()); ;
         }
 
         public Result RemoveType(string type)
@@ -50,7 +50,8 @@ namespace Application.Repositories
                 return new Result(false, "No type by the given name has been found");
             }
 
-            _context.Medicine_Types.Remove(medicineType);
+            medicineType.Status = Domain.EntityStatus.Archived.ToString().ToLower(); //Soft-Delete
+            _context.Medicine_Types.Update(medicineType);
             _context.SaveChanges();
             return new Result(true);
         }

--- a/dataservice/Domain/Entities/MedicalData/DoseUnit.cs
+++ b/dataservice/Domain/Entities/MedicalData/DoseUnit.cs
@@ -11,5 +11,6 @@ namespace Domain.Entities.MedicalData
 
         [Key]
         public string Unit { get; set; }
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/Entities/MedicalData/Medicine.cs
+++ b/dataservice/Domain/Entities/MedicalData/Medicine.cs
@@ -17,6 +17,6 @@ namespace Domain.Entities.MedicalData
         public string? Color { get; set; }
         [Required]
         public string? Type { get; set; }
-
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/Entities/MedicalData/MedicineColor.cs
+++ b/dataservice/Domain/Entities/MedicalData/MedicineColor.cs
@@ -11,5 +11,6 @@ namespace Domain.Entities.MedicalData
 
         [Key]
         public string Color { get; set; }
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/Entities/MedicalData/MedicineShape.cs
+++ b/dataservice/Domain/Entities/MedicalData/MedicineShape.cs
@@ -11,5 +11,6 @@ namespace Domain.Entities.MedicalData
 
         [Key]
         public string Shape { get; set; }
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/Entities/MedicalData/MedicineType.cs
+++ b/dataservice/Domain/Entities/MedicalData/MedicineType.cs
@@ -11,5 +11,6 @@ namespace Domain.Entities.MedicalData
 
         [Key]
         public string Type { get; set; }
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/Entities/MedicalData/PatientIntake.cs
+++ b/dataservice/Domain/Entities/MedicalData/PatientIntake.cs
@@ -18,5 +18,6 @@ namespace Domain.Entities.MedicalData
         public int Amount { get; set; }
 
         public virtual Medicine Medicine { get; set; }
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/Entities/PatientData/Patient.cs
+++ b/dataservice/Domain/Entities/PatientData/Patient.cs
@@ -20,5 +20,7 @@ namespace Domain.Entities.PatientData
         public string? PostalCode { get; set; }
 
         public string? HomeNumber { get; set; }
+
+        public string Status { get; set; } = EntityStatus.Active.ToString().ToLower();
     }
 }

--- a/dataservice/Domain/EntityStatus.cs
+++ b/dataservice/Domain/EntityStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace Domain
+{
+    public enum EntityStatus
+    {
+        Active,
+        Archived
+    }
+}

--- a/dataservice/Infrastructure/Migrations/MedicineDbMigrations/20220423084400_Added_EntityStatus.Designer.cs
+++ b/dataservice/Infrastructure/Migrations/MedicineDbMigrations/20220423084400_Added_EntityStatus.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations.MedicineDbMigrations
 {
     [DbContext(typeof(MedicineDbContext))]
-    partial class MedicineDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220423084400_Added_EntityStatus")]
+    partial class Added_EntityStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dataservice/Infrastructure/Migrations/MedicineDbMigrations/20220423084400_Added_EntityStatus.cs
+++ b/dataservice/Infrastructure/Migrations/MedicineDbMigrations/20220423084400_Added_EntityStatus.cs
@@ -1,0 +1,340 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations.MedicineDbMigrations
+{
+    public partial class Added_EntityStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "PatientIntakes",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Medicine_Types",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Medicine_Shapes",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Medicine_Colors",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Medicine",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "DoseUnits",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.UpdateData(
+                table: "DoseUnits",
+                keyColumn: "Unit",
+                keyValue: "mg",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "DoseUnits",
+                keyColumn: "Unit",
+                keyValue: "µg",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Colors",
+                keyColumn: "Color",
+                keyValue: "Blauw",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Colors",
+                keyColumn: "Color",
+                keyValue: "Geel",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Colors",
+                keyColumn: "Color",
+                keyValue: "Groen",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Colors",
+                keyColumn: "Color",
+                keyValue: "Rood",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Colors",
+                keyColumn: "Color",
+                keyValue: "Wit",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Colors",
+                keyColumn: "Color",
+                keyValue: "Zwart",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Shapes",
+                keyColumn: "Shape",
+                keyValue: "Hexagonaal",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Shapes",
+                keyColumn: "Shape",
+                keyValue: "Rond",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Shapes",
+                keyColumn: "Shape",
+                keyValue: "Vierkant",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Types",
+                keyColumn: "Type",
+                keyValue: "Capsule",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Types",
+                keyColumn: "Type",
+                keyValue: "Pil",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Types",
+                keyColumn: "Type",
+                keyValue: "Spuit",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "Medicine_Types",
+                keyColumn: "Type",
+                keyValue: "Tablet",
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.UpdateData(
+                table: "PatientIntakes",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "Status",
+                value: "active");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PatientIntakes_MedicineId",
+                table: "PatientIntakes",
+                column: "MedicineId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PatientIntakes_Medicine_MedicineId",
+                table: "PatientIntakes",
+                column: "MedicineId",
+                principalTable: "Medicine",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PatientIntakes_Medicine_MedicineId",
+                table: "PatientIntakes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PatientIntakes_MedicineId",
+                table: "PatientIntakes");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "PatientIntakes");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Medicine_Types");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Medicine_Shapes");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Medicine_Colors");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Medicine");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "DoseUnits");
+        }
+    }
+}

--- a/dataservice/Infrastructure/Migrations/PatientDbMigrations/20220423084558_Added_EntityStatus.Designer.cs
+++ b/dataservice/Infrastructure/Migrations/PatientDbMigrations/20220423084558_Added_EntityStatus.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations.PatientDbMigrations
 {
     [DbContext(typeof(PatientDbContext))]
-    partial class PatientDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220423084558_Added_EntityStatus")]
+    partial class Added_EntityStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dataservice/Infrastructure/Migrations/PatientDbMigrations/20220423084558_Added_EntityStatus.cs
+++ b/dataservice/Infrastructure/Migrations/PatientDbMigrations/20220423084558_Added_EntityStatus.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations.PatientDbMigrations
+{
+    public partial class Added_EntityStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Patients",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.UpdateData(
+                table: "Patients",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Status",
+                value: "active");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Patients");
+        }
+    }
+}


### PR DESCRIPTION
Gave all database tracked entities a status of 'Active' or 'Archived'. I've chosen to work with an enum in code since its likely to be a one time thing in this operation and doesn't have to be tracked in the db because of that. 

After a delete the items state goes to archived. This means you will not get the item when retrieving a list but you can still request it on its unique ID. 

Hope this is what we are looking for

![image](https://user-images.githubusercontent.com/63774238/164887707-d361470a-b888-4a7f-babd-a10c6391fc0f.png)
![image](https://user-images.githubusercontent.com/63774238/164887722-5eecf82a-b2d5-4c40-8807-58c91721cc8c.png)
